### PR TITLE
Modified _get_context_device() helper routine

### DIFF
--- a/cuda_core/cuda/core/experimental/_stream.pyx
+++ b/cuda_core/cuda/core/experimental/_stream.pyx
@@ -318,10 +318,10 @@ cdef class Stream:
 
     cdef _get_device_and_context(self):
         # Get the stream context first
-        if self._ctx_handle is None:
-            err, self._ctx_handle = driver.cuStreamGetCtx(self._handle)
-            raise_if_driver_error(err)
         if self._device_id is None:
+            if self._ctx_handle is None:
+                err, self._ctx_handle = driver.cuStreamGetCtx(self._handle)
+                raise_if_driver_error(err)
             self._device_id = get_device_from_ctx(self._ctx_handle)
             raise_if_driver_error(err)
 


### PR DESCRIPTION
To fix test failures with CTK 11.8 and driver 535.247.01 only attempt to query _ctx_handle if _device_id is None.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.

