### PR TITLE
chore: autoregen cuda-bindings from cybind efa59a1

### DIFF
--- a/cuda_bindings/cuda/bindings/nvjitlink.pyx
+++ b/cuda_bindings/cuda/bindings/nvjitlink.pyx
@@ -11,6 +11,8 @@ from cuda.bindings._internal._fast_enum import FastEnum as _cyb_FastEnum
 # <<<< END OF PREAMBLE CONTENT >>>>
 
 
+# cybind-autoregen-bot: prototype smoke-test marker (safe to delete)
+
 cimport cython  # NOQA
 
 from ._internal.utils cimport (get_resource_ptr, get_nested_resource_ptr, nested_resource, nullable_unique_ptr,


### PR DESCRIPTION
Autoregen of `cuda_bindings/` from cybind `efa59a1`.

Source: https://gitlab-master.nvidia.com/leof/cybind/-/commit/efa59a1

Produced by `.gitlab/publish-regen.py` (prototype).